### PR TITLE
If there are empty lines in jls output jails get skipped

### DIFF
--- a/sshjail.py
+++ b/sshjail.py
@@ -23,6 +23,9 @@ class Connection(object):
             lines = stdout.strip().split('\n')
             found = False
             for line in lines:
+                if line.strip() == '':
+                    break
+
                 jid, name, hostname, path = line.strip().split()
                 if name == self.jailspec or hostname == self.jailspec:
                     self.jid = jid


### PR DESCRIPTION
jls sometimes outputs empty lines. This causes any references to match_jail to fail on the line.strip().split():

``` python
"/home/ajette/ias-platform-management/deployment/connection_plugins/sshjail.py", line 91, in exec_command
jcmd = ['jexec', self.get_jail_id()]
File "/home/ajette/ias-platform-management/deployment/connection_plugins/sshjail.py", line 45, in get_jail_id
self.match_jail()
File "/home/ajette/ias-platform-management/deployment/connection_plugins/sshjail.py", line 28, in match_jail
jid, name, hostname, path = line.strip().split()
```
