### PR TITLE
Makes fully compatible with Python 3

### DIFF
--- a/sshjail.py
+++ b/sshjail.py
@@ -5,6 +5,7 @@ import pipes
 
 from ansible.errors import AnsibleError
 from ansible.plugins.connection.ssh import Connection as SSHConnection
+from ansible.module_utils._text import to_text
 from contextlib import contextmanager
 
 __metaclass__ = type
@@ -260,7 +261,7 @@ class Connection(ConnectionBase):
                 if line.strip() == '':
                     break
 
-                jid, name, hostname, path = line.strip().split()
+                jid, name, hostname, path = to_text(line).strip().split()
                 if name == self.jailspec or hostname == self.jailspec:
                     self.jid = jid
                     self.jname = name
@@ -352,7 +353,7 @@ class Connection(ConnectionBase):
         code, stdout, stderr = self._jailhost_command('mktemp')
         if code != 0:
             raise AnsibleError("failed to make temp file:\n%s\n%s" % (stdout, stderr))
-        tmp = stdout.strip().split(b'\n')[-1]
+        tmp = to_text(stdout.strip().split(b'\n')[-1])
 
         code, stdout, stderr = self._jailhost_command(' '.join(['chmod 0644', tmp]))
         if code != 0:

--- a/sshjail.py
+++ b/sshjail.py
@@ -254,7 +254,7 @@ class Connection(ConnectionBase):
                 display.vvv("JLS stdout: %s" % stdout)
                 raise AnsibleError("jls returned non-zero!")
 
-            lines = stdout.strip().split('\n')
+            lines = stdout.strip().split(b'\n')
             found = False
             for line in lines:
                 if line.strip() == '':
@@ -352,7 +352,7 @@ class Connection(ConnectionBase):
         code, stdout, stderr = self._jailhost_command('mktemp')
         if code != 0:
             raise AnsibleError("failed to make temp file:\n%s\n%s" % (stdout, stderr))
-        tmp = stdout.strip().split('\n')[-1]
+        tmp = stdout.strip().split(b'\n')[-1]
 
         code, stdout, stderr = self._jailhost_command(' '.join(['chmod 0644', tmp]))
         if code != 0:


### PR DESCRIPTION
The plugin is calling `exec_command()` from Ansible's SSH connection plugin, which returns `b''` strings. I was getting a TypeError when sshjail tried to split the byte string with a native string in Python 3. That's fixed by the first commit.

The second commit ensures that values used later in a native string context are converted to native strings using Ansible's Python 2- and 3-friendly `to_text()` method.