### PR TITLE
Add support for iocage instead of jexec

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,7 +79,10 @@ This means any commands executed by sshjail roughly translate to `sudo jexec $ja
 An alternative to requiring root access is to use the [`jailme`](http://www.freshports.org/sysutils/jailme) utility.
 `jailme` is "a setuid version of jexec to allow normal users access to FreeBSD jails".
 
-If you want to use `jailme`, you'll need to ensure it's installed on the jailhost, and specify the user to `sudo` as
+Another alternavite to requering root acces is to use the [`iocage`](https://www.freshports.org/sysutils/iocage/) utility.
+`iocage` is a "jail/container manager amalgamating some of the bestfeatures and technologies the FreeBSD operating system has to offer"
+
+If you want to use `jailme` or `iocage`, you'll need to ensure it's installed on the jailhost, and specify the user to `sudo` as
 via `--become-user` on the command line, or `become_user: username` in a play or task. sshjail will prefer to use `jailme`
 if it's installed, whether you are sudoing as root or not.
 

--- a/sshjail.py
+++ b/sshjail.py
@@ -340,6 +340,10 @@ class Connection(ConnectionBase):
 
     def get_jail_connector(self):
         if self.connector is None:
+            code, _, _ = self._jailhost_command("which -s iocage")
+            if code == 0:
+                self.connector = 'iocage'
+                return self.connector
             code, _, _ = self._jailhost_command("which -s jailme")
             if code != 0:
                 self.connector = 'jexec'


### PR DESCRIPTION
I create Jails with iocage.
`jexec` don't work with jail hostname when it's created from iocage.

Edit changed priority:
iocage > jailme > jexec