### PR TITLE
Add support for ansible-core 2.11

### DIFF
--- a/sshjail.py
+++ b/sshjail.py
@@ -49,6 +49,17 @@ DOCUMENTATION = '''
           vars:
               - name: ansible_password
               - name: ansible_ssh_pass
+      sshpass_prompt:
+          description: Password prompt that sshpass should search for. Supported by sshpass 1.06 and up
+          default: ''
+          ini:
+              - section: 'ssh_connection'
+                key: 'sshpass_prompt'
+          env:
+              - name: ANSIBLE_SSHPASS_PROMPT
+          vars:
+              - name: ansible_sshpass_prompt
+          version_added: '2.10'
       ssh_args:
           description: Arguments to pass to all ssh cli tools
           default: '-C -o ControlMaster=auto -o ControlPersist=60s'
@@ -247,6 +258,16 @@ DOCUMENTATION = '''
         vars:
           - name: ansible_sftp_batch_mode
             version_added: '2.7'
+      ssh_transfer_method:
+        default: smart
+        description:
+            - "Preferred method to use when transferring files over ssh"
+            - Setting to 'smart' (default) will try them in order, until one succeeds or they all fail
+            - Using 'piped' creates an ssh pipe with ``dd`` on either side to copy the data
+        choices: ['sftp', 'scp', 'piped', 'smart']
+        env: [{name: ANSIBLE_SSH_TRANSFER_METHOD}]
+        ini:
+            - {key: transfer_method, section: ssh_connection}
       scp_if_ssh:
         default: smart
         description:
@@ -270,6 +291,27 @@ DOCUMENTATION = '''
         vars:
           - name: ansible_ssh_use_tty
             version_added: '2.7'
+      timeout:
+        default: 10
+        description:
+            - This is the default ammount of time we will wait while establishing an ssh connection
+            - It also controls how long we can wait to access reading the connection once established (select on the socket)
+        env:
+            - name: ANSIBLE_TIMEOUT
+            - name: ANSIBLE_SSH_TIMEOUT
+              version_added: '2.11'
+        ini:
+            - key: timeout
+              section: defaults
+            - key: timeout
+              section: ssh_connection
+              version_added: '2.11'
+        vars:
+            - name: ansible_ssh_timeout
+              version_added: '2.11'
+        cli:
+            - name: timeout
+        type: integer
 '''
 
 try:


### PR DESCRIPTION
The ssh connector plugins added the new following variables: `sshpass_prompt`, `ssh_transfer_method`, and `timeout`. This causes the sshjail plugin to fail with the following error.

```
An exception occurred during task execution. To see the full traceback, use -vvv. The error was: KeyError: 'Requested entry (plugin_type: connection plugin: sshjail setting: ssh_transfer_me
thod ) was not defined in configuration.'                                                                                                                                                    
nginx.shams | FAILED! => {                                                                                                                                                                   
    "msg": "Unexpected failure during module execution.",                                                                                                                                    
    "stdout": ""                                                                                                                                                                             
} 
```

This PR fixes the bug by adding the new variables to sshjail's `DOCUMENTATION` string.