### PR TITLE
Remove default ssh port 22

### DIFF
--- a/sshjail.py
+++ b/sshjail.py
@@ -168,7 +168,6 @@ DOCUMENTATION = '''
       port:
           description: Remote port to connect to.
           type: int
-          default: 22
           ini:
             - section: defaults
               key: remote_port


### PR DESCRIPTION
This allows whatever is configured in ~/.ssh/config to
take precedence.

This way, ssh connections work like they do for "normal"
(as in "non-jail") hosts, where ansible itself doesn't
pass a default port ito ssh, but instead uses whatever the
ssh implementation choses - which allows whatever is
in ~/.ssh/config to be applied.

By setting a default of 22 this breaks for accessing jails
on jailhosts, as ansible explicitly passes in port 22 everytime
a jailhost is accessed and the user is forced to override it
explicitly in the inventory.

Besides being inconvenient this also introduces inconsistencies,
as accessing somejail@somehost uses a different port than accessing
somehost (as the former always uses 22 if nothing else is specified,
while the latter uses whatever ssh decides to use).

Removing the default addresses this problem without breaking things,
as the ssh default port 22 is still used by the ssh if not
overridden in ssh configuration.