### PR TITLE
Fix issues with quoting

### DIFF
--- a/sshjail.py
+++ b/sshjail.py
@@ -3,6 +3,7 @@ from __future__ import (absolute_import, division, print_function)
 
 import os
 import pipes
+import shlex
 
 from ansible.errors import AnsibleError
 from ansible.plugins.connection.ssh import Connection as SSHConnection
@@ -389,14 +390,30 @@ class Connection(ConnectionBase):
         return self.connector
 
     def _strip_sudo(self, executable, cmd):
-        # Get the command without sudo
-        sudoless = cmd.rsplit(executable + ' -c ', 1)[1]
-        # Get the quotes
-        quotes = sudoless.partition('echo')[0]
-        # Get the string between the quotes
-        cmd = sudoless[len(quotes):-len(quotes+'?')]
-        # Drop the first command becasue we don't need it
-        cmd = cmd.split('; ', 1)[1]
+        # cmd looks like:
+        #     sudo -H -S -n  -u root /bin/sh -c 'echo BECOME-SUCCESS-hnjapeqklmbeniylaoledvqttgvyefbd ; test -e /usr/local/bin/python || ( pkg install -y python )'
+        # or
+        #     /bin/sh -c 'sudo -H -S -n  -u root /bin/sh -c '"'"'echo BECOME-SUCCESS-xuaumtxycchjfekyxlbykjbqxosupbpd ; /usr/local/bin/python2.7 /root/.ansible/tmp/ansible-tmp-1629053721.2637851-12131-255051228590176/AnsiballZ_pkgng.py'"'"''
+
+        # we need to extract just:
+        #     test -e /usr/local/bin/python || ( pkg install -y python )
+        # or
+        #     /usr/local/bin/python2.7 /root/.ansible/tmp/ansible-tmp-1629053721.2637851-12131-255051228590176/AnsiballZ_pkgng.py
+
+        # to do this, we peel back successive command invocations
+        words = shlex.split(cmd)
+        while words[0] == executable or words[0] == 'sudo':
+            cmd = words[-1]
+            words = shlex.split(cmd)
+        
+        # after, cmd is:
+        #    echo BECOME-SUCCESS-hnjapeqklmbeniylaoledvqttgvyefbd ; test -e /usr/local/bin/python || ( pkg install -y python )
+        # or:
+        #    echo BECOME-SUCCESS-xuaumtxycchjfekyxlbykjbqxosupbpd ; /usr/local/bin/python2.7 /root/.ansible/tmp/ansible-tmp-1629053721.2637851-12131-255051228590176/AnsiballZ_pkgng.py
+
+        # drop first command
+        cmd = cmd.split(' ; ', 1)[1]
+
         return cmd
 
     def _strip_sleep(self, cmd):


### PR DESCRIPTION
Fixes #34. There are some cases where quote stripping (needed when
ansible would otherwise try to run sudo in a jail) would remove too
little or too many quotes. This attempts to rectify this using
shlex-based parsing (mostly).