### PR TITLE
Unbreak sshjail: Add changes for ansible 2.12

### DIFF
--- a/sshjail.py
+++ b/sshjail.py
@@ -266,6 +266,9 @@ DOCUMENTATION = '''
         env: [{name: ANSIBLE_SSH_TRANSFER_METHOD}]
         ini:
             - {key: transfer_method, section: ssh_connection}
+        vars:
+            - name: ansible_ssh_transfer_method
+              version_added: '2.12'
       scp_if_ssh:
         default: smart
         description:
@@ -310,6 +313,17 @@ DOCUMENTATION = '''
         cli:
             - name: timeout
         type: integer
+      pkcs11_provider:
+        version_added: '2.12'
+        default: ""
+        description:
+          - "PKCS11 SmartCard provider such as opensc, example: /usr/local/lib/opensc-pkcs11.so"
+          - Requires sshpass version 1.06+, sshpass must support the -P option.
+        env: [{name: ANSIBLE_PKCS11_PROVIDER}]
+        ini:
+          - {key: pkcs11_provider, section: ssh_connection}
+        vars:
+          - name: ansible_ssh_pkcs11_provider
 '''
 
 try:


### PR DESCRIPTION
Fixes this error:

```
ansible.errors.AnsibleError: Requested entry (plugin_type: connection plugin: sshjail setting: pkcs11_provider ) was not defined in configuration.
```
