### PR TITLE
Avoid warning with ansible-core-2.13

### DIFF
--- a/sshjail.py
+++ b/sshjail.py
@@ -24,6 +24,7 @@ DOCUMENTATION = '''
           description: Hostname/ip to connect to.
           default: inventory_hostname
           vars:
+               - name: inventory_hostname
                - name: ansible_host
                - name: ansible_ssh_host
       host_key_checking:


### PR DESCRIPTION
When using with latest ansible sshjail causes the following warning:

```
[WARNING]: The "sshjail" connection plugin has an improperly configured remote target value, forcing "inventory_hostname"
templated value instead of the string
```

This patch fixes the issue.