### PR TITLE
Upgrade sshjail to currently working version

### DIFF
--- a/sshjail.py
+++ b/sshjail.py
@@ -469,6 +469,7 @@ class Connection(ConnectionBase):
         if 'sudo' in cmd:
             cmd = self._strip_sudo(executable, cmd)
 
+        self.set_option('host', self.host)
         cmd = ' '.join([executable, '-c', pipes.quote(cmd)])
         if slpcmd:
             cmd = '%s %s %s %s' % (self.get_jail_connector(), self.get_jail_id(), cmd, '&& sleep 0')

--- a/sshjail.py
+++ b/sshjail.py
@@ -2,9 +2,8 @@
 from __future__ import (absolute_import, division, print_function)
 
 import os
-from packaging import version
-import pipes
 import shlex
+from packaging import version
 
 from ansible import __version__ as ansible_version
 from ansible.errors import AnsibleError
@@ -470,7 +469,7 @@ class Connection(ConnectionBase):
             cmd = self._strip_sudo(executable, cmd)
 
         self.set_option('host', self.host)
-        cmd = ' '.join([executable, '-c', pipes.quote(cmd)])
+        cmd = ' '.join([executable, '-c', shlex.quote(cmd)])
         if slpcmd:
             cmd = '%s %s %s %s' % (self.get_jail_connector(), self.get_jail_id(), cmd, '&& sleep 0')
         else:

--- a/sshjail.py
+++ b/sshjail.py
@@ -266,6 +266,9 @@ DOCUMENTATION = '''
         env: [{name: ANSIBLE_SSH_TRANSFER_METHOD}]
         ini:
             - {key: transfer_method, section: ssh_connection}
+        vars:
+            - name: ansible_ssh_transfer_method
+              version_added: '2.12'
       scp_if_ssh:
         default: smart
         description:
@@ -310,6 +313,17 @@ DOCUMENTATION = '''
         cli:
             - name: timeout
         type: integer
+      pkcs11_provider:
+        version_added: '2.12'
+        default: ""
+        description:
+          - "PKCS11 SmartCard provider such as opensc, example: /usr/local/lib/opensc-pkcs11.so"
+          - Requires sshpass version 1.06+, sshpass must support the -P option.
+        env: [{name: ANSIBLE_PKCS11_PROVIDER}]
+        ini:
+          - {key: pkcs11_provider, section: ssh_connection}
+        vars:
+          - name: ansible_ssh_pkcs11_provider
 '''
 
 try:

--- a/sshjail.py
+++ b/sshjail.py
@@ -28,6 +28,7 @@ DOCUMENTATION = '''
           description: Hostname/ip to connect to.
           default: inventory_hostname
           vars:
+               - name: inventory_hostname
                - name: ansible_host
                - name: ansible_ssh_host
       host_key_checking:

--- a/sshjail.py
+++ b/sshjail.py
@@ -297,6 +297,17 @@ DOCUMENTATION = '''
         vars:
           - name: ansible_ssh_use_tty
             version_added: '2.7'
+      pkcs11_provider:
+        version_added: '2.12'
+        default: ''
+        description:
+          - PKCS11 SmartCard provider such as opensc, example: /usr/local/lib/opensc-pkcs11.so
+          - Requires sshpass version 1.06+, sshpass must support the -P option.
+        env: [{name: ANSIBLE_PKCS11_PROVIDER}]
+        ini:
+          - {key: pkcs11_provider, section: ssh_connection}
+        vars:
+          - name: ansible_ssh_pkcs11_provider
       timeout:
         default: 10
         description:
@@ -463,9 +474,11 @@ class Connection(ConnectionBase):
         return os.path.join(prefix, normpath[1:])
 
     def _copy_file(self, from_file, to_file, executable='/bin/sh'):
-        plugin = self.become
-        shell = get_shell_plugin(executable=executable)
-        copycmd = plugin.build_become_command(' '.join(['cp', from_file, to_file]), shell)
+        copycmd = ' '.join(['cp', from_file, to_file])
+        if self._play_context.become:
+            plugin = self.become
+            shell = get_shell_plugin(executable=executable)
+            copycmd = plugin.build_become_command(copycmd, shell)
 
         display.vvv(u"REMOTE COPY {0} TO {1}".format(from_file, to_file), host=self.inventory_hostname)
         code, stdout, stderr = self._jailhost_command(copycmd)

--- a/sshjail.py
+++ b/sshjail.py
@@ -1,9 +1,11 @@
-# Copyright (c) 2015-2018, Austin Hyde (@austinhyde)
+# Copyright (c) 2015-2021, Austin Hyde (@austinhyde)
 from __future__ import (absolute_import, division, print_function)
 
 import os
+from packaging import version
 import pipes
 
+from ansible import __version__ as ansible_version
 from ansible.errors import AnsibleError
 from ansible.plugins.connection.ssh import Connection as SSHConnection
 from ansible.module_utils._text import to_text
@@ -11,6 +13,8 @@ from ansible.plugins.loader import get_shell_plugin
 from contextlib import contextmanager
 
 __metaclass__ = type
+
+MIN_ANSIBLE_VERSION = '2.11.3'
 
 DOCUMENTATION = '''
     connection: sshjail
@@ -345,6 +349,8 @@ class Connection(ConnectionBase):
         self.jpath = None
         self.connector = None
 
+        if version.parse(ansible_version) < version.parse(MIN_ANSIBLE_VERSION):
+            raise AnsibleError("sshjail needs at least ansible version " + MIN_ANSIBLE_VERSION)
         # logging.warning(self._play_context.connection)
 
     def match_jail(self):

--- a/sshjail.py
+++ b/sshjail.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2015-2021, Austin Hyde (@austinhyde)
+# Copyright (c) 2015-2025, Austin Hyde (@austinhyde)
 from __future__ import (absolute_import, division, print_function)
 
 import os

--- a/sshjail.py
+++ b/sshjail.py
@@ -329,17 +329,6 @@ DOCUMENTATION = '''
         cli:
             - name: timeout
         type: integer
-      pkcs11_provider:
-        version_added: '2.12'
-        default: ""
-        description:
-          - "PKCS11 SmartCard provider such as opensc, example: /usr/local/lib/opensc-pkcs11.so"
-          - Requires sshpass version 1.06+, sshpass must support the -P option.
-        env: [{name: ANSIBLE_PKCS11_PROVIDER}]
-        ini:
-          - {key: pkcs11_provider, section: ssh_connection}
-        vars:
-          - name: ansible_ssh_pkcs11_provider
 '''
 
 try:


### PR DESCRIPTION
This basically is what we're running at the moment, it includes various fixes from github issues and pull requests, which I listed below for closing. It also brings back the minimum ansible version check, which at this point (four years later) should really be not an issue anymore 🤞.

Closes #33, closes #34, closes #36, closes #38, closes #39, closes #40, closes #41, closes #42
